### PR TITLE
Bug fix for Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
   }
 
   </style>
-  <link href="./node_modules/swagger-editor-dist/swagger-editor.css" rel="stylesheet">
+  <link href="node_modules/swagger-editor-dist/swagger-editor.css" rel="stylesheet">
 </head>
 
 <body>
@@ -47,7 +47,6 @@
   <script>
 
     // Reset local-storage plugin content
-    localStorage.setItem('swagger-editor-content', ' ');
     $.get("/editor/spec", function(spec) {
       localStorage.setItem('swagger-editor-content', spec);
     });
@@ -58,31 +57,24 @@
      * in the same tab.
      */
     var originalSetItem = localStorage.setItem;
-    localStorage.setItem = function() {
-      var event = new Event('localStorageItemUpdated');
+    localStorage.setItem = function(key, value) {
+      var event = new CustomEvent('localStorageItemUpdated', {
+        detail: {
+          'key': key,
+          'value': value
+        }
+      });
       document.dispatchEvent(event);
       originalSetItem.apply(this, arguments);
     }
 
-
-    document.addEventListener("localStorageItemUpdated", function(e) {
-      $.ajax({
-        url: "/editor/spec",
-        type: "PUT",
-        data: editor.spec().get('spec'),
-        success: function(data) {
-          console.log(data);
-        }
-      });
-    }, false);
-
   </script>
-  <script src="./node_modules/swagger-editor-dist/swagger-editor-bundle.js"> </script>
-  <script src="./node_modules/swagger-editor-dist/swagger-editor-standalone-preset.js"> </script>
+  <script src="node_modules/swagger-editor-dist/swagger-editor-bundle.js"> </script>
+  <script src="node_modules/swagger-editor-dist/swagger-editor-standalone-preset.js"> </script>
   <script>
   window.onload = function() {
     // Build a system
-    const editor = SwaggerEditorBundle({
+    var editor = SwaggerEditorBundle({
       dom_id: '#swagger-editor',
       layout: 'StandaloneLayout',
       presets: [
@@ -90,7 +82,24 @@
       ]
     });
 
-    window.editor = editor
+    window.editor = editor;
+
+    document.addEventListener("localStorageItemUpdated", function(e) {
+      if (e.detail.key !== 'swagger-editor-content') {
+        return;
+      }
+      
+      $.ajax({
+        url: "/editor/spec",
+        type: "PUT",
+        data: e.detail.value,
+        success: function(data) {
+          console.log(data);
+        }
+      });
+
+    }, false);
+
   }
   </script>
 


### PR DESCRIPTION
**Bug**: Refreshing in Safari wipes out Swagger file.

**Cause**:
It looks like editor().spec().get('spec') returns empty string if you call it right after updating local storage. I was able to fix this by putting editor().spec().get('spec') into setTimeout function. It looks like it is related to timing. 

**Fix**:
Used CustomEvent instead of Event in order to set custom data for localStorageItemUpdated event to use the data in the event callback. 
