### PR TITLE
Walkaround issue #13

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var path = require('path');
 var fs = require('fs');
 var open = require('open');
 var nodeModules = path.resolve(path.resolve(__dirname, ''), 'node_modules');
-if (!fs.existsSync(nodeModules)) {
+if (!fs.existsSync(nodeModules + "/swagger-editor-dist")) {
   nodeModules = path.resolve('node_modules');
 }
 var express = require('express');


### PR DESCRIPTION
For local package installation, swagger-editor-dist folder should be set for existence, not only node_modules.

Currently, if new version of dependent module was installed globally, e.g. commander, then sub-node_modules will contain that folder only, and swagger-editor-dist will be installed in upper level
```
- package.json
  | - node_modules
  |   | - commander (v5.0)
  |   | - swagger-editor-dist
  |   | - swagger-editor-live
  |   |   | - node_modules
  |   |   |  | - commander (v2.9.0)
```

in that case, npm swagger-editor-live file.yaml will fail with Error: ENOENT: no such file or directory

This path check should walk around that situation